### PR TITLE
Added half a minimal root implementation, fleshed out code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
+.idea
 Manifest.toml
+docs/build

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,5 @@ authors = ["Ulrich Thiel <thiel@mathematik.uni-kl.de>"]
 version = "0.1.0"
 
 [deps]
-AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -6,3 +6,4 @@ version = "0.1.0"
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Readme.md
+++ b/Readme.md
@@ -40,3 +40,9 @@ To run tests, first activate the package, then run the `test` command repeatedly
 To build the documentation:
 
     julia --project=docs/  docs/make.jl
+
+You can run a local server to preview the documentation (some of the hyperlinks don't work otherwise):
+
+    python3 -m http.server --directory docs/build/ 8181
+
+and now open <http://localhost:8181/> in the browser.

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,12 @@ See [here](https://github.com/ulthiel/CoxeterGroups.jl/issues/1).
 
 ## Development
 
-Checkout the code, change directory in, and start the julia shell. To run tests:
+Checkout the code, change directory in, and start the julia shell.
+To run tests, first activate the package, then run the `test` command repeatedly while editing.
 
     pkg> activate .
     pkg> test
+
+To build the documentation:
+
+    julia --project=docs/  docs/make.jl

--- a/Readme.md
+++ b/Readme.md
@@ -27,3 +27,11 @@ a
 ## Todo
 
 See [here](https://github.com/ulthiel/CoxeterGroups.jl/issues/1).
+
+
+## Development
+
+Checkout the code, change directory in, and start the julia shell. To run tests:
+
+    pkg> activate .
+    pkg> test

--- a/benchmarks/julia.jl
+++ b/benchmarks/julia.jl
@@ -1,0 +1,47 @@
+using CoxeterGroups
+
+function enumerate_whole_group(G::CoxGrp)
+    id = one(G)
+    seen = Set([id])
+    queue = [id]
+    gens = generators(G)
+
+    i = 1
+    while i <= length(queue)
+        for s = gens
+            ws = queue[i] * s
+            if ws ∉ seen
+                push!(seen, ws)
+                push!(queue, ws)
+            end
+        end
+
+        i += 1
+    end
+
+    return queue
+end
+
+function multiply_all_pairs(Gelts)
+    sum = 0
+    for x = Gelts, y = Gelts
+        sum += length(x * y)
+    end
+    return sum
+end
+
+# CoxeterGroup
+# For A5, took about 3 us per element. Magma takes about 0.2 us per element.
+# For A6, took about 6.8 us per element. Magma takes about 0.2 us per element.
+# G, S = CoxeterGroup(coxeter_type("A", 4).coxeter_mat)
+
+# CoxGrpMin
+# For A5, took about 0.25 us per element. Magma takes about 0.20 us per element.
+# For A6, took about 0.33 us per element. Magma takes about 0.26 us per element.
+G, S = coxeter_group_min(coxeter_type("A", 4).gcm)
+
+Gelts = enumerate_whole_group(G)
+time = @elapsed lengthsum = multiply_all_pairs(Gelts)
+us_per_elt = time * 1_000_000 / length(Gelts)^2
+print("Took about $us_per_elt us per element\n")
+print(lengthsum)

--- a/benchmarks/magma.m
+++ b/benchmarks/magma.m
@@ -1,0 +1,67 @@
+// The purpose of this script is to try to get an idea of the speed of Magma's GrpFPCox implementation.
+// It should be run like this:
+//     magma -b type:=A6 magma.m
+//
+// The script will compute all elements of the given group, then multiply all ordered pairs of elements in the group.
+// In order to try to account for the interpretation overhead in Magma, we run another loop over all ordered pairs which
+// does a very simple computation, and remove that from the time.
+
+SetColumns(0);
+
+function AllElementsToLength(W : maxLength := -1)
+    queue := {@ W.0 @};
+    pos := 1;
+    while pos le #queue do
+        w := queue[pos];
+        pos +:= 1;
+
+        for s := 1 to Rank(W) do
+            ws := w * W.s;
+            if #w lt #ws and (maxLength eq -1 or #ws le maxLength) then
+                Include(~queue, ws);
+            end if;
+        end for;
+    end while;
+
+    return queue;
+end function;
+
+function SumLengths(Welts)
+    sum := 0;
+    for x in Welts, y in Welts do
+        sum +:= #x + #y;
+    end for;
+    return sum;
+end function;
+
+function Multiply(Welts)
+    sum := 0;
+    for x in Welts, y in Welts do
+        sum +:= #(x * y);
+    end for;
+    return sum;
+end function;
+
+W := CoxeterGroup(GrpFPCox, type);
+Welts := AllElementsToLength(W);
+
+printf "Working in type %o with %o elements\n", type, #Welts;
+
+start := Realtime();
+SumLengths(Welts);
+sumtime := Realtime(start);
+
+start := Realtime();
+Multiply(Welts);
+multtime := Realtime(start);
+
+usPerElt := (multtime - sumtime) / #Welts^2 * 1000 * 1000;
+
+printf "It took %o seconds to sum the lengths of all pairs of elements,\n", sumtime;
+printf "and     %o seconds to sum the lengths of the product of all pairs of elements.\n", multtime;
+printf "Hence the internal Magma multiplication takes about %o μs per element.\n", usPerElt;
+
+
+
+
+quit;

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+CoxeterGroups = "670e43dd-5bed-4a23-a2c5-7c7db0ec8412"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,4 @@
+using Documenter
+using CoxeterGroups
+
+makedocs(sitename="CoxeterGroups.jl Documentation")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,8 @@
+# CoxeterGroups.jl Documentation
+
+Coxeter groups and their elements are subtypes of the abstract types [`CoxGrp`](@ref) and [`CoxElt`](@ref).
+
+```@docs
+CoxGrp
+CoxElt
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,49 @@
 # CoxeterGroups.jl Documentation
 
 Coxeter groups and their elements are subtypes of the abstract types [`CoxGrp`](@ref) and [`CoxElt`](@ref).
+Currently there are two (incomplete) implementations, which can be constructed using either [`CoxeterGroup`](@ref) or [`coxeter_group_min`](@ref).
+The constructor takes a matrix, which can be either a generalised Cartan matrix, or a Coxeter matrix (currently `coxeter_group_min` cannot accept a Coxeter matrix), and returns a group object and list of generators.
+For example:
+
+```
+W, (s, t) = coxeter_group_min([2 -1; -1 2])
+s*t*s == t*s*t
+```
+
+The interface for Coxeter group objects is that they are subtypes of [`CoxGrp`](@ref), and implement the functions
+
+- `CoxeterGroups.rank(W)` returns the rank, i.e. number of generators.
+- `CoxeterGroups.generators(W)` returns a list of generators.
+- `Base.one(W)` returns the group identity.
+- Coxeter group objects compare equal `==` only if they are exactly the same object in memory. Isomorphic groups are not equal.
+
+The interface for Coxeter group elements is they are subtypes of [`CoxElt`](@ref), and implement the functions
+
+- `Base.parent(w)` returns the parent Coxeter group.
+- `Base.isone(w)` to check if an element is the identity.
+- `Base.length(w)` to return the Coxeter length.
+- Coxeter group elements compare equal `==` if and only if they represent the same element of the same parent. Coxeter group elements are immutable and work like values: they can be hashed and used as keys in a dictionary.
+- `*`, `inv`, and `w^k` should work on group elements.
+- `CoxeterGroups.is_right_descent(w, s)` returns true if the integer `s`, which represents a simple generator, is in the right descent set of `w`.
+- `CoxeterGroups.is_left_descent(s, w)` works similarly.
 
 ```@docs
 CoxGrp
 CoxElt
+coxeter_group_min
+CoxeterGroup
+```
+
+
+## Minimal roots implementation
+
+The _minimal roots_ implementation of a Coxeter group represents group elements by words in the Coxeter generators in ShortLex normal form.
+Operations on these words are done with the assistance of a _minimal root reflection table_, which needs to be constructed when the group is created.
+
+Currently this implementation can handle any Coxeter group defined by a generalised Cartan matrix, but this is only because generating the minimal root reflection table is more difficult for general Coxeter groups.
+The same underlying algorithms will work once given a new table.
+
+```@docs
+CoxeterGroups.CoxGrpMin
+CoxeterGroups.create_reflection_table_gcm
 ```

--- a/src/CoxMin.jl
+++ b/src/CoxMin.jl
@@ -1,0 +1,329 @@
+# CoxMin contains the CoxGrpMin and CoxEltMin implementations which use the minimal root automaton.
+import LinearAlgebra: I, dot
+
+export coxeter_group_min
+
+"A Coxeter group, implemented using the minimal root reflection table."
+mutable struct CoxGrpMin <: CoxGrp
+    "The Coxeter matrix. Zero entries stand for infinity."
+    coxeter_matrix::Matrix{Int64}
+
+    # refl_table[s, α] is the reflection s⋅α of the root. The simple roots are numbered from 1 up to the rank,
+    # the other minimal roots are numbered arbitrarily. refl_table[s, s] = 0 for each simple root s, and also
+    # refl_table[s, α] = 0 if s⋅α leaves the set of minimal roots.
+    # Since Julia stores matrices in column-major order, this (rather than the transpose) seems like the most
+    # sensible layout.
+    refl_table::Matrix{Int64}
+
+    # is_finite stores whether the Coxeter group is finite or not. This can also be determined by looking for
+    # holes in the refl_table, but we will cache the result of this search here.
+    is_finite::Bool
+end
+
+
+"""
+A CoxEltMin is a representation of a Coxeter group element in ShortLex normal form: as a word in the generators,
+this is the lexicographically least reduced expression. Fixing a particular normal form means that equality testing
+and hashing of Coxeter group elements is straightforward, as each has a unique representation.
+"""
+struct CoxEltMin <: CoxElt
+    # Parent group
+    group::CoxGrpMin
+
+    # ShortLex normal form of the word. (Supports Coxeter groups with up to 255 generators, numbered [1, 255]).
+    word::Vector{UInt8}
+end
+
+
+"""Create a Coxeter group from a GCM. (TODO: Allow a Coxeter matrix to be passed)."""
+function coxeter_group_min(mat::Matrix{T}) where T <: Integer
+    if !is_gcm(mat)
+        throw(DomainError(mat, "Is not a generalised Cartan matrix"))
+    end
+
+    # Rank of the system.
+    n, _ = size(mat)
+
+    # Generate the minimal root reflection table using the GCM algorithm.
+    refl_table = create_reflection_table_gcm(mat)
+
+    # There are n zeros in the reflection table always, coming from the simple reflections reflecting
+    # their simple roots to negative. If there are more than n zeros, then there are some non-minimal
+    # positive roots, and the resulting group is infinite.
+    is_finite = count(x -> x == 0, refl_table) > n
+    G = CoxGrpMin(gcm_to_coxeter_matrix(mat), refl_table, is_finite)
+    return G, generators(G)
+end
+
+
+"The generators of the Coxeter group, in order."
+generators(grp::CoxGrpMin) = [CoxEltMin(grp, [s]) for s=1:rank(grp)]
+
+rank(grp::CoxGrpMin) = size(grp.coxeter_matrix)[1]
+
+"The identity of the Coxeter group."
+Base.one(grp::CoxGrpMin) = CoxEltMin(grp, [])
+
+"Check if `w` is the identity of the Coxeter group."
+Base.isone(w::CoxEltMin) = length(w.word) == 0
+
+"The length of a Coxeter group element"
+Base.length(w::CoxEltMin) = length(w.word)
+
+"Check equality between Coxeter group elements"
+Base.:(==)(w::CoxEltMin, x::CoxEltMin) = w.word == x.word
+
+Base.hash(w::CoxEltMin, h::UInt) = hash(w.word, h)
+
+"Print a Coxeter group element in ShortLex normal form"
+#Base.show(io::IO, x::CoxEltMin) = join(io, x.word)
+
+"Check whether s is a right descent of w."
+function is_right_descent(w::CoxEltMin, t::Integer)
+    if !(1 <= t <= rank(w.group))
+        throw(DomainError(t, "$t is not a generator in the range [1, $(rank(w.group))]"))
+    end
+
+    # Let t be a reflection (not necessarily simple) with corresponding root α, and w any group element.
+    # Then l(wt) < l(w) if and only if w⋅α < 0.
+    # Hence given a reduced expression s(1) ... s(n), not necessarily in ShortLex normal form, we may test
+    # if α becomes negative by running s(n)⋅α, s(n-1)⋅(s(n)⋅α), etc through the minimal root reflection table.
+    root = Int64(t)
+
+    # It seems that neither Base.reverse or Iterators.reverse can iterate over a vector in reverse without
+    # causing an allocation?
+    for i = length(w.word):-1:1
+        s = w.word[i]
+
+        # If we are about to reflect to a negative root, since the rest of the word is reduced we will never
+        # make it back to a positive root. Hence root becomes negative in the result.
+        if s == root
+            return true
+
+        # If we are about to reflect to a non-minimal root, then since the word is reduced we'll also never
+        # make it back to the minimal roots.
+        elseif w.group.refl_table[s, root] == 0
+            return false
+        end
+
+        root = w.group.refl_table[s, root]
+    end
+
+    return false
+end
+
+"Check whether s is a left descent of w."
+function is_left_descent(w::CoxEltMin, t::Integer)
+    if !(1 <= t <= rank(w.group))
+        throw(DomainError(t, "$t is not a generator in the range [1, $(rank(w.group))]"))
+    end
+
+    # See the comments in is_right_descent(), here we are just reversing the order in which we read the word.
+    root = UInt8(t)
+    for s = w.word
+        if s == root
+            return true
+        elseif w.group.refl_table[s, root] == 0
+            return false
+        end
+
+        root = w.group.refl_table[s, root]
+    end
+
+    return false
+end
+
+"""
+Multiply a word on the right by a simple generator t, mutating the word.
+The word must be reduced, and if it is a ShortLex normal form, then the resulting
+word will also be a ShortLex normal form.
+"""
+function _mult_r!(refl::Matrix{Int64}, word::Array{UInt8}, t::UInt8)
+    # We proceed along the word from right-to-left, looking for either an insertion point or a deletion point.
+    # A priori, we don't know which will take place (insertion or deletion).
+    # If a deletion eventually takes place, its location is unique and there is only one thing to do.
+    # If an insertion is to take place there might be multiple valid places to insert a letter (the obvious place
+    # is at the end), but we want to choose the place which makes the result as lexicographically least as possible.
+
+    # Let word = s(1) ... s(n). We start with the root t, and incrementally calculate the reflections s(n)⋅t,
+    # s(n-1) s(n) ⋅ t, and so on. For 1 <= i <= n, let α = s(i+1)...s(n)⋅t be the root so far, which we assume
+    # inductively to be a minimal root (so in particular, still positive). We start out with the potential insertion
+    # position at the back, and the potential insertion letter equal to t.
+    # By considering s(i) and α there are several cases:
+    #   1. s(i)⋅α < 0 iff α is the simple root corresponding to s(i). If this happens, then since the word is reduced
+    #      the root will stay negative, and we are looking at a deletion. The reflection corresponding to the root
+    #      α is s(i+1) ... s(n) t s(n) ... s(i+1) = s(i), and hence we have s(i+1) ... s(n) t = s(i) ... s(n). After
+    #      replacing, we have an s(i)^2 which can be deleted. So in this case we are looking at a deletion at s(i).
+    #
+    #   2. s(i)⋅α is the simple root corresponding to some other generator r. In this case we get another insertion
+    #      point: considering the reflection associated to α we have s(i) ... s(n) = r s(i) ... s(n), so the new
+    #      insertion point is to insert r just before position i. If r < s(i) lexicographically then this gives a
+    #      better insertion point than previously, and so we update our best insertion point. Otherwise, do nothing.
+    #
+    #   3. s(i)⋅α is still positive, but no longer minimal. In this case since the word is reduced we will forever
+    #      stay in the set of non-minimal positive roots, so we have an insertion. Return the best insertion point
+    #      so far.
+    # If nothing special happens, then simply update the root and continue. If we reach the start of the word then
+    # we have an insertion, so return the best insertion so far.
+
+    insertion_point = length(word) + 1
+    insertion_letter = t
+    root = Int64(t)
+    for i = length(word):-1:1
+        # Deletion case
+        if word[i] == root
+            deleteat!(word, i)
+            return
+        end
+
+        root = refl[word[i], root]
+        if root == 0
+            # No longer minimal: return the best insertion point.
+            break
+        end
+
+        # Check if we have a better insertion point now. Since word[i] is a simple
+        # root, if root < word[i] it must be simple.
+        if root < word[i]
+            insertion_point = i
+            insertion_letter = UInt8(root)
+        end
+    end
+
+    insert!(word, insertion_point, insertion_letter)
+    return
+end
+
+"The product ``wx`` of Coxeter group elements."
+function Base.:(*)(w::CoxEltMin, x::CoxEltMin)
+    if w.group != x.group
+        throw(ArgumentError("The elements come from different Coxeter groups"))
+    end
+
+    refl = w.group.refl_table
+    word = copy(w.word)
+    for s = x.word
+        _mult_r!(refl, word, s)
+    end
+
+    return CoxEltMin(w.group, word)
+end
+
+# TODO: Perhaps this function should be gone, and we should require explicit conversions.
+"""
+The product ``ws`` of Coxeter group elements, where ``s`` is the simple reflection
+numbered by ``s``.
+"""
+function Base.:(*)(w::CoxEltMin, s::T) where T <: Integer
+    !(1 <= s <= rank(w.group)) && throw(DomainError(s, "$s is not a generator in the range [1, $(rank(w.group))]"))
+    word = copy(w.word)
+    _mult_r!(w.group.refl_table, word, UInt8(s))
+    return CoxEltMin(w.group, word)
+end
+
+
+"The inverse ``w^{-1}`` of a Coxeter group element"
+function Base.inv(x::CoxEltMin)
+    refl = w.group.refl_table
+    word = UInt8[]
+    sizehint!(word, length(x.word))
+
+    for s in reverse(x.word)
+        _mult_r!(refl, word, s)
+    end
+
+    return CoxEltMin(w.group, word)
+end
+
+@doc raw"""
+    create_reflection_table_gcm(gcm)
+
+Create the minimal root reflection table for a Coxeter group defined by a GCM (generalised Cartan matrix).
+This is a straightforward algorithm since we need only deal with integers, rather than algebraic integers.
+
+The return value is a matrix `refl_table` of size R×T, where R is the rank of the group (the size of the square GCM),
+and T is the number of minimal roots. The minimal roots are indexed from 1:T, with the first 1:R of them corresponding
+to the simple roots, and the other indices arbitrary.
+
+If ``β = s(α)`` is a minimal root, then `refl_table[s, α]` stores the index of β, and otherwise `refl_table[s, α] = 0`.
+Note that `refl_table[s, s] = 0` for every simple root `s`.
+"""
+function create_reflection_table_gcm(gcm::Matrix{T}) where T <: Integer
+    if !is_gcm(gcm)
+        throw(DomainError(gcm, "Not a generalised Cartan matrix"))
+    end
+
+    # My convention for the Cartan matrix is that gcm[i, j] = ⟨α_i^, α_j⟩. Not that it particularly matters here,
+    # since a transposed Cartan matrix yields the same Coxeter system.
+
+    # We will keep track of root vectors in the simple root basis, and their associated coroots in the simple
+    # coroot basis: both the simple roots and coroots start out as coordinate vectors. We then start generating
+    # the root system by reflecting anywhere we can to get new roots. The pairing between the two bases is
+    # using the Cartan matrix.
+    # The condition ⟨β, α_s⟩ ≤ -2 which is used to detect whether s(β) is non-minimal in the symmetric case can
+    # be replaced by the condition that ⟨β^, α_s⟩⟨α_s^, β⟩ ≥ 4. (Both these conditions are equivalent to the pair
+    # {s, r_β} of reflections generating an infinite dihedral group).
+
+    # We will keep the roots and coroots in parallel arrays, and keep an extra dictionary mapping a root
+    # to its index in this array, which will also serve as a marker for whether we have seen a root before.
+    n, _ = size(gcm)
+    id = Matrix{T}(I, n, n)
+    roots = [id[s, :] for s = 1:n]
+    coroots = [id[s, :] for s = 1:n]
+    rootidx = Dict(roots[s] => s for s = 1:n)
+
+    # The reflection table maps (s, i) to the index of s(roots[i]). If s(roots[i]) is negative (this happens
+    # iff roots[i] is the simple reflection corresponding to s, iff s = i) then refl[s, i] = 0, and if
+    # s(roots[i]) is no longer a minimal root, then refl[s, i] = 0.
+    refl = Dict((s, s) => 0 for s = 1:n)
+
+    i = 1
+    while i <= length(roots)
+        for s = 1:n
+            # If the reflection s(roots[i]) has already been calculated, skip. This will happen once
+            # for each root, since it already knows what lower reflection first created it.
+            if haskey(refl, (s, i))
+                continue
+            end
+
+            # Calculate the pairing ⟨α_s^, roots[i]⟩ and the copairing ⟨coroots[i], α_s⟩.
+            pairing = dot(gcm[s, :], roots[i])
+            copairing = dot(coroots[i], gcm[:, s])
+            if pairing * copairing >= 4
+                refl[s, i] = 0
+                continue
+            end
+
+            # Calculate the reflection s(roots[i]).
+            new_root = copy(roots[i])
+            new_root[s] -= pairing
+
+            # If we've not seen this root before, then add it to our list.
+            if !haskey(rootidx, new_root)
+                push!(roots, new_root)
+
+                new_coroot = copy(coroots[i])
+                new_coroot[s] -= copairing
+                push!(coroots, new_coroot)
+
+                rootidx[new_root] = length(roots)
+            end
+
+            # Record the reflection data.
+            si = rootidx[new_root]
+            refl[s, i] = si
+            refl[s, si] = i
+        end
+        i += 1
+    end
+
+    # Reassemble our reflection data into a matrix, where the rows are indexed by simple reflections
+    # and the columns are indexed by roots. Iterating over all possible root indices and simple reflections
+    # double-checks that we have defined all reflections.
+    refltab = zeros(Int64, n, length(roots))
+    for i = 1:length(roots), s = 1:n
+        refltab[s, i] = refl[s, i]
+    end
+
+    return refltab
+end

--- a/src/CoxeterGroupData.jl
+++ b/src/CoxeterGroupData.jl
@@ -1,0 +1,111 @@
+import LinearAlgebra: diagind
+
+export coxeter_type, is_coxeter_matrix
+
+"""
+    is_coxeter_matrix(mat)
+
+Check if an integer matrix is a Coxeter matrix. A Coxeter matrix is a square symmetric matrix with integer entries,
+where the diagonal elements are 1, and then off-diagonal elements are in {0} ∪ {2, 3, 4, ...}. Under this convention,
+a zero represents ∞.
+"""
+function is_coxeter_matrix(mat::Matrix{T}) where T <: Integer
+    n, m = size(mat)
+    return (
+        n == m
+        && all(mat[i, i] == 1 for i = 1:n)
+        && all(mat[i, j] == mat[j, i] for i = 1:n, j = 1:n if i != j)
+        && all(mat[i, j] == 0 || mat[i, j] >= 2 for i = 1:n, j = 1:n if i != j)
+    )
+end
+
+
+"""
+    is_gcm(mat)
+
+Check if an integer matrix is a generalised Cartan matrix. A generalised Cartan matrix (GCM) is a square
+matrix with integer entries, such that:
+
+1. All diagonal entries are 2,
+2. All off-diagonal entries are 0 or negative, and
+3. ``a_{ij} = 0`` if and only if ``a_{ji} = 0``.
+"""
+function is_gcm(mat::Matrix{T}) where T <: Integer
+    n, m = size(mat)
+    return (
+        n == m
+        && all(mat[i, i] == 2 for i = 1:n)
+        && all(mat[i, j] <= 0 for i = 1:n, j = 1:n if i != j)
+        && all(mat[i, j] == 0 for i = 1:n, j = 1:n if mat[j, i] == 0)
+    )
+end
+
+
+"""
+    gcm_to_coxeter_matrix(gcm)
+
+Convert a generalised Cartan matrix to its corresponding Coxeter matrix."""
+function gcm_to_coxeter_matrix(gcm::Matrix{T}) where T <: Integer
+    if !is_gcm(gcm)
+        throw(DomainError(gcm, "Is not a generalised Cartan matrix"))
+    end
+
+    # Replace each entry with a_{ij} a_{ji}, then map (0, 1, 2, 3, ≥ 4) to m_{ij} = (2, 3, 4, 6, 0 = ∞).
+    # Finally, replace the diagonal with 1's and return.
+    function a_to_m(a)
+        a == 0 && return 2
+        a == 1 && return 3
+        a == 2 && return 4
+        a == 3 && return 6
+        return 0
+    end
+
+    cartan_mat = map(a_to_m, gcm .* gcm)
+    cartan_mat[diagind(cartan_mat)] .= 1
+    return cartan_mat
+end
+
+
+"""A CoxType holds metadata about a Coxeter group"""
+struct CoxType
+    """Rank of the Coxeter group."""
+    rank::Int
+
+    """Generalised Cartan matrix. Omitted for non-crystallographic types, like H3 and H4."""
+    gcm::Matrix{Int}
+
+    """Coxeter matrix."""
+    coxeter_mat::Matrix{Int}
+
+    """Whether the group is finite."""
+    # is_finite::Bool
+
+    """The number of reflections in the group (half the number of roots). Omitted for infinite groups."""
+    # refl_count::Int
+
+    """The number of elements in the group. Omitted for infinite groups."""
+    weyl_order::BigInt
+
+    """The exponents of the group, in increasing order. Omitted for infinite groups."""
+    # exponents::Vector{Int}
+end
+
+"""Convenience method for constructing a CoxType from the GCM and weyl order only."""
+function coxeter_type_from_gcm(gcm::Matrix{Int}, weyl_order::BigInt)
+    @assert is_gcm(gcm)
+
+    return CoxType(size(gcm, 1), gcm, gcm_to_coxeter_matrix(gcm), weyl_order)
+end
+
+"""Construct a CoxType from a letter and rank, like ("A", 4) for the symmetric group S5."""
+function coxeter_type(letter::String, rank::Int)
+    if letter == "A"
+        gcm = zeros(Int64, rank, rank)
+        gcm[diagind(gcm)] .= 2
+        gcm[diagind(gcm, 1)] .= -1
+        gcm[diagind(gcm, -1)] .= -1
+        return coxeter_type_from_gcm(gcm, factorial(big(rank + 1)))
+    end
+
+    throw(DomainError(letter, "Unknown letter"))
+end

--- a/src/CoxeterGroups.jl
+++ b/src/CoxeterGroups.jl
@@ -6,11 +6,12 @@ import AbstractAlgebra: MatElem#, MatrixAlgebra
 import Nemo: matrix, ZZ, fmpz
 import Base: *,<,>
 export CoxeterGroup, CoxeterElement, setCoxeterGroup, setRelation!, getRelation, getCoxeterMatrix, getCoxeterGroup, rank, generators
+export CoxGrp, CoxElt
 
-"Abstract supertype for Coxeter groups"
+"Abstract supertype for Coxeter groups."
 abstract type CoxGrp end
 
-"Abstract supertype for Coxeter group elements"
+"Abstract supertype for Coxeter group elements."
 abstract type CoxElt end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,42 @@
+using Test
+using CoxeterGroups
+
+# Construct every element of the group by right-multiplying by generators.
+# Used for some basic tests to see if the group is being constructed correctly.
+function enumerate_whole_group(G::CoxeterGroup)
+    id = one(G)
+    seen = Set([id])
+    queue = [id]
+    gens = generators(G)
+
+    i = 1
+    while i <= length(queue)
+        for s = gens
+            ws = queue[i] * s
+            if ws ∉ seen
+                push!(seen, ws)
+                push!(queue, ws)
+            end
+        end
+
+        i += 1
+    end
+
+    return queue
+end
+
+
+# We should be able to construct the trivial group with a 0x0 Coxeter matrix.
+S1, () = CoxeterGroup(Array{Int64}(undef, 0, 0), String[])
+S1Elts = enumerate_whole_group(S1)
+@test length(S1Elts) == 1
+
+
+S2, (s,) = CoxeterGroup([1;;], ["s"])
+S2Elts = enumerate_whole_group(S2)
+@test length(S2Elts) == 2
+
+
+S3, (s, t) = CoxeterGroup([1 3; 3 1], ["s", "t"])
+S3Elts = enumerate_whole_group(S3)
+@test length(S3Elts) == 6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,15 @@
 using Test
 using CoxeterGroups
 
+# Check our predicates are working.
+@test is_coxeter_matrix(Array{Int64}(undef, 0, 0))
+@test is_coxeter_matrix([1;;])
+@test !is_coxeter_matrix([2;;])
+
+
 # Construct every element of the group by right-multiplying by generators.
 # Used for some basic tests to see if the group is being constructed correctly.
-function enumerate_whole_group(G::CoxeterGroup)
+function enumerate_whole_group(G::CoxGrp)
     id = one(G)
     seen = Set([id])
     queue = [id]
@@ -25,18 +31,18 @@ function enumerate_whole_group(G::CoxeterGroup)
     return queue
 end
 
+# Test each of the different implementations
+group_constructors = [
+    coxeter_group_min,
+    CoxeterGroup,
+]
 
-# We should be able to construct the trivial group with a 0x0 Coxeter matrix.
-S1, () = CoxeterGroup(Array{Int64}(undef, 0, 0), String[])
-S1Elts = enumerate_whole_group(S1)
-@test length(S1Elts) == 1
-
-
-S2, (s,) = CoxeterGroup([1;;], ["s"])
-S2Elts = enumerate_whole_group(S2)
-@test length(S2Elts) == 2
-
-
-S3, (s, t) = CoxeterGroup([1 3; 3 1], ["s", "t"])
-S3Elts = enumerate_whole_group(S3)
-@test length(S3Elts) == 6
+# For each implementation, check they generate the correct number of elements in the symmetric group.
+for group_constructor = group_constructors
+    for rank = 0:5
+        type = coxeter_type("A", rank)
+        W, gens = group_constructor(type.gcm)
+        Welts = enumerate_whole_group(W)
+        @test length(Welts) == type.weyl_order
+    end
+end


### PR DESCRIPTION
This PR adds a lot of code, I think the bones of a good structure are there, but it certainly needs more discussion, and don't take any of it as the final word! Here is a summary of the changes.

1. Added some documentation, and started sketching out an interface in there.
2. Added the `CoxGrpMin` minimal roots implementation - currently it works for crystallographic cases only (i.e. it can eat generalised Cartan matrices and output minimal root reflection tables). I have Python code which can generate the reflection tables for the general case but I have not translated it yet - an alternative to the finnicky combinatorial approach would be to import some powerful number field stuff from OSCAR.
3. Added the beginnings of a `coxeter_type` function, which takes a specification of a group like `("A", 4)` and returns data about `A4`: GCM, Coxeter matrix, size of group, and so on. This is used in the tests, for example.
4. Removed `AbstractAlgebra` and `Nemo` for now, because the special types are not needed for the core implementation of Coxeter groups, and my unfamiliarity with both them and Julia at the same time is too much. I look forward to discussing how CoxeterGroups can slot into the OSCAR ecosystem with those that have some more experience.
5. Removed a few methods of the existing `CoxeterGroup` implementation, as I thought they were unnecessary or unhelpful. Renamed some more, or some of my own, so that function names are shared across both implementations.
6. Added some tests.
7. I've introduced two abstract types `CoxGrp` and `CoxElt` to organise the types. The different implementations are working: look in the test file for where both implementations are tested at once.
8. I also made some crude benchmarks to see how we're doing versus the `GrpFPCox` implementation in Magma. On a test that goes through all ordered pairs of the 5040 elements of S7 and multiplies them, the `CoxeterGroup` implementation takes 6.8 μs per element, the `CoxGrpMin` implementation takes 0.33 μs per element, and Magma takes 0.26 μs per element. So the minimal roots implementation is in the ballpark of a good implementation I think.


Some thoughts for the future, written here before I forget:

9. Currently `CoxeterGroup` and `CoxGrpMin` use different internal orderings: one is ShortLex and the other is InvShortLex. What should the behaviour of the Julia operators `<` and `>` be?
10. `CoxeterGroup` uses mutability of group elements a bit, which I think can be problematic. I think group elements should be immutable value types, i.e. they never change their meaning, and they compare equal if and only if they have the same meaning. Like integers.