### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,68 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          - '1.7'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        include:
+          - os: windows-latest
+            version: '1'
+            arch: x64
+          - os: macOS-latest
+            version: '1'
+            arch: x64
+          - os: ubuntu-latest
+            version: '1'
+            arch: x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - run: |
+          julia --project=docs -e '
+            using Documenter: DocMeta, doctest
+            using CoxeterGroups
+            DocMeta.setdocmeta!(CoxeterGroups, :DocTestSetup, :(using CoxeterGroups); recursive=true)
+            doctest(CoxeterGroups)'

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -8,3 +8,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Match = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compact]
+julia = "1.6"
+Match = "1"

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,9 @@
 # CoxeterGroups.jl
 
+[![][docs-dev-img]][docs-dev-url]
+[![][action-img]][action-url]
+[![][codecov-img]][codecov-url]
+
 A Julia package for computing in Coxeter groups (draft, under development).
 
 The current code is due to T. Schmit (2021) and implements the algorithm from the paper
@@ -51,3 +55,13 @@ If the documentation build is complaining about missing dependencies, then run
     $ julia --project=docs/
     julia> ]
     pkg> resolve
+
+<!-- URLS -->
+
+
+[action-img]: https://github.com/ulthiel/CoxeterGroups.jl/actions/workflows/CI.yml/badge.svg
+[action-url]: https://github.com/ulthiel/CoxeterGroups.jl/actions
+[codecov-img]: https://codecov.io/gh/ulthiel/CoxeterGroups.jl/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/ulthiel/CoxeterGroups.jl?branch=master
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://ulthiel.github.io/CoxeterGroups.jl/dev/

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,114 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CoxeterGroups]]
+deps = ["LinearAlgebra", "Match", "SparseArrays", "Test"]
+path = ".."
+uuid = "670e43dd-5bed-4a23-a2c5-7c7db0ec8412"
+version = "0.1.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "5158c2b41018c5f7eb1470d558127ac274eca0c9"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.1"
+
+[[Documenter]]
+deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "6030186b00a38e9d0434518627426570aac2ef95"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.27.23"
+
+[[IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.2"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.3"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Match]]
+git-tree-sha1 = "1d9bc5c1a6e7ee24effb93f175c9342f9154d97f"
+uuid = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
+version = "1.2.0"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "595c0b811cf2bab8b0849a70d9bd6379cc1cfb52"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.4.1"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,4 +2,13 @@ using Documenter
 using CoxeterGroups
 import CoxeterGroups: CoxeterSystem
 
-makedocs(sitename="CoxeterGroups.jl Documentation")
+DocMeta.setdocmeta!(CoxeterGroups, :DocTestSetup, :(using CoxeterGroups); recursive=true)
+
+makedocs(;
+    modules=[CoxeterGroups],
+    sitename="CoxeterGroups.jl"
+)
+
+deploydocs(;
+    repo="github.com/ulthiel/CoxeterGroups.jl",
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,8 @@ using CoxeterGroups
 
 # Check our predicates are working.
 @test is_coxeter_matrix(Array{Int64}(undef, 0, 0))
-@test is_coxeter_matrix([1;;])
-@test !is_coxeter_matrix([2;;])
+@test is_coxeter_matrix(ones(Int, 1, 1))
+@test !is_coxeter_matrix(reshape([2], 1, 1))
 
 
 # Construct every element of the group by right-multiplying by generators.
@@ -58,7 +58,7 @@ end
 # the implementation of these operations is correct).
 groups = [
     coxeter_group_min(Array{Int64}(undef, 0, 0)),
-    coxeter_group_min([2;;]),                       # A1, GCM
+    coxeter_group_min(reshape([2], 1, 1)),                       # A1, GCM
     coxeter_group_min([2 -1; -1 2]),                # A2, GCM
     coxeter_group_min([2 -1 0; -1 2 -1; 0 -1 2]),   # A3, GCM
     coxeter_group_min([1 3 2; 3 1 3; 2 3 1]),       # A3, Coxeter matrix
@@ -102,7 +102,7 @@ end
 
 matrices = Dict{String,Matrix{Int64}}()
 matrices["A0"] = Array{Int64}(undef, 0, 0)
-matrices["A1"] = [1;;]
+matrices["A1"] = ones(Int, 1, 1)
 matrices["A2"] = [1 3;3 1]
 matrices["A3"] = [1 3 2;3 1 3;2 3 1]
 matrices["A4"] = [1 3 2 2;3 1 3 2;2 3 1 3;2 2 3 1]


### PR DESCRIPTION
It would be convenient if the test-CI is turned on.

# main changes
1. Add the CI-test and docs-deployer to the GitHub workflows. Note that the docs-deployer requires a `ssh-key` of documenter in the repo. See my [page](https://rexwzh.github.io/CoxeterGroups.jl/dev/) for a sample. The username has been replaced in this branch.

2. Edited some tests for the sack of compatibility, considering that Julia1.6 is a long term supported version.
```jl
# In Julia 1.6
julia> [1;;] # get a vector instead of a matrix
1-element Vector{Int64}:
 1
```